### PR TITLE
Eliminates instructions for panda

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ files of each module if you experience problems.
 
 If you have a working Rakudo Perl 6 installation then you should be able to do:
 
-	 panda install Task::Noise
-
-or
-
 	zef install Task::Noise
 
 depending on your preference.


### PR DESCRIPTION
Trying to address this: perl6/ecosystem-unbitrot#48
There's actually no problem after all the issues with the other files have been fixed, but this anyway is no longer OK.